### PR TITLE
Contest search page added

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -8,6 +8,7 @@ import Contests from './Pages/Contests';
 import Practice from './Pages/Practice';
 import Analysis from './Pages/Analysis';
 import Blogs from './Pages/Blogs';
+import ContestSearch from './Pages/ContestSearch';
 import {UserContextProvider} from './Context/user-context'
 
 
@@ -23,6 +24,7 @@ function App() {
     <Route path="/practice" element={<Practice />} />
     <Route path="/analysis" element={<Analysis />} />
     <Route path = "/blogs" element={<Blogs />} />
+    <Route path = "/searchcontest" element={<ContestSearch />} />
     {/* <Route path="*" element={<NotFound />} />  */}
     </Routes>
     </UserContextProvider>

--- a/src/Pages/ContestProblems.js
+++ b/src/Pages/ContestProblems.js
@@ -1,0 +1,122 @@
+import React from 'react'
+
+import Paper from '@mui/material/Paper';
+import Box from '@mui/material/Box';
+import Table from '@mui/material/Table';
+import TableBody from '@mui/material/TableBody';
+import TableCell from '@mui/material/TableCell';
+import TableContainer from '@mui/material/TableContainer';
+import TableHead from '@mui/material/TableHead';
+import TablePagination from '@mui/material/TablePagination';
+import TableRow from '@mui/material/TableRow';
+export const ContestProblems = ({contestName,contestProblems}) => {
+    console.log(contestName);
+    console.log(contestProblems);
+    
+    let problems = contestProblems;
+    const [page, setPage] = React.useState(0);
+    const rowsPerPage = 10;
+    const handleClickProblem = (e,problem) =>{
+        e.preventDefault();
+        window.open(`https://codeforces.com/contest/${problem.contestId}/problem/${problem.index}`,'_blank');
+    }
+    const handleChangePage = (event, newPage) => {
+        setPage(newPage);
+      };
+      const emptyRows =
+      page > 0 ? Math.max(0, (1 + page) * rowsPerPage - problems.length) : 0;
+      return (
+        <Box sx={{ width: '100%' }}>
+          <Paper sx={{ width: '100%', mb: 2 }}>
+            
+            <TableContainer>
+              <Table
+                sx={{ minWidth: 750 }}
+                aria-labelledby="tableTitle"
+                size={'medium'}
+              >
+                
+                <ContestPageHead/>
+    
+                <TableBody>
+                  
+                  {problems
+                    .slice(page * rowsPerPage, page * rowsPerPage + rowsPerPage)
+                    .map((problem, index) => {
+                      const labelId = `enhanced-table-checkbox-${index}`;
+                      return (
+                        <TableRow
+                          hover
+                          style = {{cursor: 'pointer'}}
+                          onClick={(event) => handleClickProblem(event, problem)}
+                          tabIndex={-1}
+                          key={problem.name}
+                        >
+                          <TableCell align="left">{`${problem.contestId}${problem.index}`}</TableCell>
+                          <TableCell
+                            component="th"
+                            id={labelId}
+                            scope="row">
+                            {problem.name}
+                          </TableCell>
+                          <TableCell align="left">{problem.rating}</TableCell>
+                        </TableRow>
+                      );
+                    })}
+                  {emptyRows > 0 && (
+                    <TableRow
+                      style={{
+                        height: '2rem',
+                      }}
+                    >
+                      <TableCell colSpan={6} />
+                    </TableRow>
+                  )}
+                </TableBody>
+              </Table>
+            </TableContainer>
+            <TablePagination
+              component="div"
+              count={problems.length}
+              rowsPerPage={rowsPerPage}
+              page={page}
+              onPageChange={handleChangePage}
+            />
+          </Paper>
+        </Box>
+      );
+    
+}
+export const ContestPageHead = () => {
+    const headCells = [
+        {
+          id : 'problem id',
+          label: 'Problem ID'
+        },
+        {
+          id : 'problem',
+          label: 'Problem'
+        },
+        {
+          id : 'rating',
+          label: 'Problem Rating'
+        }
+      ]
+    
+      return (
+        <TableHead>
+          <TableRow>
+            {headCells.map((headCell) => (
+              <TableCell
+                key={headCell.id}
+                align={'left'}
+                padding={'normal'}
+              >
+                {headCell.label}
+    
+              </TableCell>
+            ))}
+          </TableRow>
+        </TableHead>
+      );
+}

--- a/src/Pages/ContestSearch.js
+++ b/src/Pages/ContestSearch.js
@@ -1,0 +1,75 @@
+import React from 'react';
+import TextField from '@mui/material/TextField';
+import Button from '@mui/material/Button';
+import { useState } from 'react';
+import { styled } from '@mui/material/styles';
+import Box from '@mui/material/Box';
+import Paper from '@mui/material/Paper';
+import Grid from '@mui/material/Grid';
+import axios from 'axios';
+import{ ContestProblems} from './ContestProblems';
+const ContestSearch = () => {
+  
+    const [contestName,setContestName] = useState("");
+    const [contestProblems,setContestProblems] = useState([]);
+    const [isSubmitted,setSubmitStatus] = useState(false);
+    const handleContestChange = (e) => {        
+        setContestName(e.target.value);
+        setSubmitStatus(false);
+      }
+      const TableItem = styled(Paper)(() => ({
+        padding: '2rem',
+        margin:'2rem',
+      }));
+   
+      const handleContestSubmit =async (e) => {
+        let contestRes = await axios.get(" https://codeforces.com/api/contest.list?gym=false");
+        let contestList = contestRes.data.result;
+        contestList = contestList.filter((contest) => contest.name === contestName && contest.phase === "FINISHED");  
+        console.log(contestList); 
+        try{
+        const problemsres = await axios.get(`https://codeforces.com/api/problemset.problems?tags=`);
+        let problemsArr = problemsres.data.result.problems;
+        problemsArr = problemsArr.filter((problem)=> problem.contestId === contestList[0].id);
+        console.log(problemsArr);
+        problemsArr.reverse();
+        setContestProblems(problemsArr);
+        
+        }
+        catch(err){
+            console.log(err);
+        }
+        setSubmitStatus(true);      
+      }
+
+      return (
+        <>
+          <form style = {{textAlign:'center'}} onSubmit={handleContestSubmit}>
+          <TextField id="outlined-basic" 
+             label="Contest Name" 
+             variant="outlined"
+             onChange={handleContestChange}
+             value ={contestName} />
+
+            <Button onClick={handleContestSubmit} style={{padding: '1rem', margin : '0 1rem'}} variant="contained">Find Contest</Button>
+
+          </form>
+          {contestName.length > 0 && isSubmitted === true &&
+          (<>
+          <Box >
+          <Grid container spacing={2}>
+            
+            <Grid item xs={12}>
+              <TableItem>
+                {<ContestProblems contestName = { contestName} contestProblems = { contestProblems}/>}
+              </TableItem>
+            </Grid>
+    
+          </Grid>
+      </Box></>)}
+        </>
+    );
+}
+
+
+export default ContestSearch

--- a/src/Pages/Home.js
+++ b/src/Pages/Home.js
@@ -14,7 +14,7 @@ import { styled } from '@mui/material/styles';
 
 import  UserContext  from '../Context/user-context';
 import Blogs from './Blogs';
-
+import ContestSearch from './ContestSearch';
 
 const Home = () => {
 
@@ -88,6 +88,14 @@ const Home = () => {
         <Grid item xs={12}>
             <LargeItem>
             <Link to="/blogs" element={<Blogs/>} style ={linkStyle}>Blogs</Link>
+            </LargeItem>
+        </Grid>
+        </>)}
+        { (
+        <>
+        <Grid item xs={12}>
+            <LargeItem>
+            <Link to="/searchcontest" element={<ContestSearch/>} style ={linkStyle}>Search for a contest</Link>
             </LargeItem>
         </Grid>
         </>)}


### PR DESCRIPTION
I have added a card that allows us to search for a particular CF Round and displays the problems of that round. Right now, it is showing all problems as unsolved by the user, but it can be improved to mark the problems solved by the user. 
![image](https://user-images.githubusercontent.com/83954180/208250367-8ff61424-c020-4f54-91b8-b34963db8f8b.png)
![image](https://user-images.githubusercontent.com/83954180/208250387-4b782957-be14-4eae-8cac-62f48c9b2eef.png)
![image](https://user-images.githubusercontent.com/83954180/208250406-58aaea4b-6232-4182-8572-4ce0dee69c0a.png)
